### PR TITLE
Schedules via tree decompositions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,14 +5,20 @@ authors = ["Evan Patterson <evan@epatters.org>"]
 version = "0.0.1"
 
 [deps]
+AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 Catlab = "134e5e36-593f-5add-ad60-77f754baafbe"
+CliqueTrees = "60701a23-6482-424a-84db-faee86b9b1f8"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 MLStyle = "d8e11817-5142-5d16-987a-aa16d5891078"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
+AbstractTrees = "0.4.5"
 Catlab = "^0.16.4"
+CliqueTrees = "0.2.1"
 DataStructures = "0.18"
 MLStyle = "0.4"
 Reexport = "1"
+SparseArrays = "1.11.0"
 julia = "1.9"

--- a/src/ScheduleUWDs.jl
+++ b/src/ScheduleUWDs.jl
@@ -6,7 +6,7 @@ composites of morphisms in hypergraph categories.
 module ScheduleUWDs
 
 export AbstractNestedUWD, AbstractScheduledUWD, NestedUWD, ScheduledUWD,
-  SchedulingAlgorithm, SequentialSchedule, JunctionTreesSchedule,
+  SchedulingAlgorithm, SequentialSchedule, CliqueTreesSchedule,
   eval_schedule, to_nested_diagram, schedule
 
 import Base: schedule
@@ -216,14 +216,14 @@ according to the order of their IDs, which is arbitrary.
 struct SequentialSchedule <: SchedulingAlgorithm end
 
 
-""" Schedule a diagram using the tree decomposition library JunctionTrees.jl.
+""" Schedule a diagram using the tree decomposition library CliqueTrees.jl.
 
 This algorithm works by computing a tree decomposition of the diagram's dual graph.
 The user can pass the following parameters as keyword arguments to `schedule`.
 - `ealg`: algorithm for computing a fill-reducing permutation of the graph's vertices
 - `snd`: type of supernode partition
 """
-struct JunctionTreesSchedule <: SchedulingAlgorithm end
+struct CliqueTreesSchedule <: SchedulingAlgorithm end
 
 
 """ Schedule an undirected wiring diagram.
@@ -252,7 +252,7 @@ function schedule(d::AbstractUWD, ::SequentialSchedule;
   schedule
 end
 
-function schedule(diagram::AbstractUWD, ::JunctionTreesSchedule;
+function schedule(diagram::AbstractUWD, ::CliqueTreesSchedule;
                   ealg::PermutationOrAlgorithm=DEFAULT_ELIMINATION_ALGORITHM,
                   snd::SupernodeType=DEFAULT_SUPERNODE_TYPE)
     # construct supernodal elimination tree

--- a/src/ScheduleUWDs.jl
+++ b/src/ScheduleUWDs.jl
@@ -4,15 +4,21 @@ In category-theoretic terms, this module is about evaluating arbitrary
 composites of morphisms in hypergraph categories.
 """
 module ScheduleUWDs
+
 export AbstractNestedUWD, AbstractScheduledUWD, NestedUWD, ScheduledUWD,
-  SchedulingAlgorithm, SequentialSchedule,
+  SchedulingAlgorithm, SequentialSchedule, JunctionTreesSchedule,
   eval_schedule, to_nested_diagram, schedule
 
 import Base: schedule
-using DataStructures: IntDisjointSets, union!, in_same_set
+import Base.Iterators
 
+using AbstractTrees
+using DataStructures: IntDisjointSets, union!, in_same_set
 using Catlab.CategoricalAlgebra, Catlab.WiringDiagrams
 using Catlab.WiringDiagrams.UndirectedWiringDiagrams: flat
+using CliqueTrees: PermutationOrAlgorithm, SupernodeType, Tree, DEFAULT_ELIMINATION_ALGORITHM, DEFAULT_SUPERNODE_TYPE, supernodetree, setrootindex!
+using SparseArrays
+
 
 # Data types
 ############
@@ -209,6 +215,17 @@ according to the order of their IDs, which is arbitrary.
 """
 struct SequentialSchedule <: SchedulingAlgorithm end
 
+
+""" Schedule a diagram using the tree decomposition library JunctionTrees.jl.
+
+This algorithm works by computing a tree decomposition of the diagram's dual graph.
+The user can pass the following parameters as keyword arguments to `schedule`.
+- `ealg`: algorithm for computing a fill-reducing permutation of the graph's vertices
+- `snd`: type of supernode partition
+"""
+struct JunctionTreesSchedule <: SchedulingAlgorithm end
+
+
 """ Schedule an undirected wiring diagram.
 
 By default, a simple sequential schedule is used.
@@ -233,6 +250,87 @@ function schedule(d::AbstractUWD, ::SequentialSchedule;
   set_subpart!(schedule, order[1:min(2,nb)], :box_parent, 1)
   set_subpart!(schedule, order[3:nb], :box_parent, 2:nc)
   schedule
+end
+
+function schedule(diagram::AbstractUWD, ::JunctionTreesSchedule;
+                  ealg::PermutationOrAlgorithm=DEFAULT_ELIMINATION_ALGORITHM,
+                  snd::SupernodeType=DEFAULT_SUPERNODE_TYPE)
+    # construct supernodal elimination tree
+    label, stree = supernodetree(dualgraph(diagram); alg=ealg, snd)
+    
+    # assign boxes to supernodes
+    assignment = fill(length(stree), nboxes(diagram))
+    root = length(stree)
+
+    for (i, residual) in Iterators.reverse(enumerate(stree))
+        for j in @view label[residual]
+            for p in ports_with_junction(diagram, j)::Vector{Int} # type instability
+                b = box(diagram, p)
+                assignment[b] = i
+            end
+
+            for p in ports_with_junction(diagram, j; outer=true)::Vector{Int} # type instability
+                root = i
+            end
+        end
+    end
+
+    # construct schedule
+    tree = setrootindex!(Tree(stree), root)
+    schedule = ScheduledUWD()
+    copy_parts!(schedule, diagram)
+    add_parts!(schedule, :Composite, length(tree))
+
+    for i in tree
+        j = parentindex(tree, i)
+
+        if isnothing(j)
+            set_subpart!(schedule, i, :parent, i)
+        else
+            set_subpart!(schedule, i, :parent, j)
+        end
+    end
+
+    for (b, i) in enumerate(assignment)
+        set_subpart!(schedule, b, :box_parent, i)
+    end
+
+    schedule
+end
+
+# Construct the dual graph of an undirected wiring diagram.
+function dualgraph(diagram::AbstractUWD)
+    source = Int[]
+    target = Int[]
+    
+    for p in ports(diagram)
+        b = box(diagram, p)
+        i = junction(diagram, p)::Int # type instability
+        
+        for q in ports(diagram, b)
+            j = junction(diagram, q)::Int # type instability
+                
+            if i != j
+                push!(source, i)
+                push!(target, j)
+            end
+        end
+    end
+    
+    for p in ports(diagram; outer=true)
+        i = junction(diagram, p; outer=true)::Int # type instability
+        
+        for q in ports(diagram; outer=true)
+            j = junction(diagram, q; outer=true)::Int # type instability
+            
+            if i != j
+                push!(source, i)
+                push!(target, j)
+            end
+        end
+    end
+    
+    sparse(source, target, ones(Bool, length(source)), njunctions(diagram), njunctions(diagram))
 end
 
 end

--- a/test/ScheduleUWDs.jl
+++ b/test/ScheduleUWDs.jl
@@ -29,6 +29,10 @@ matrices = map(randn, [(3,4), (4,5), (5,6), (6,7)])
 out = eval_schedule(nd, matrices)
 @test out ≈ foldr(*, matrices)
 
+s = schedule(d, JunctionTreesSchedule())
+out = eval_schedule(s, matrices)
+@test out ≈ foldr(*, matrices)
+
 # Closed cycle
 ##############
 
@@ -44,6 +48,10 @@ matrices = map(randn, [(10,5), (5,5), (5,5), (5,10)])
 out = eval_schedule(nd, matrices)
 @test out[] ≈ tr(foldl(*, matrices))
 
+s = schedule(d, JunctionTreesSchedule())
+out = eval_schedule(s, matrices)
+@test out[] ≈ tr(foldl(*, matrices))
+
 # Tensor product
 ################
 
@@ -56,6 +64,10 @@ A, B = randn((3,4)), randn((5,6))
 out = eval_schedule(s, [A, B])
 @test out ≈ (reshape(A, (3,4,1,1)) .* reshape(B, (1,1,5,6)))
 
+s = schedule(d, JunctionTreesSchedule())
+out = eval_schedule(s, [A, B])
+@test out ≈ (reshape(A, (3,4,1,1)) .* reshape(B, (1,1,5,6)))
+
 # Frobenius inner product
 #########################
 
@@ -65,6 +77,10 @@ s = schedule(d)
 @test box_parent(s) == [1,1]
 
 A, B = randn((5,5)), randn((5,5))
+out = eval_schedule(s, [A, B])
+@test out[] ≈ dot(vec(A), vec(B))
+
+s = schedule(d, JunctionTreesSchedule())
 out = eval_schedule(s, [A, B])
 @test out[] ≈ dot(vec(A), vec(B))
 

--- a/test/ScheduleUWDs.jl
+++ b/test/ScheduleUWDs.jl
@@ -29,7 +29,7 @@ matrices = map(randn, [(3,4), (4,5), (5,6), (6,7)])
 out = eval_schedule(nd, matrices)
 @test out ≈ foldr(*, matrices)
 
-s = schedule(d, JunctionTreesSchedule())
+s = schedule(d, CliqueTreesSchedule())
 out = eval_schedule(s, matrices)
 @test out ≈ foldr(*, matrices)
 
@@ -48,7 +48,7 @@ matrices = map(randn, [(10,5), (5,5), (5,5), (5,10)])
 out = eval_schedule(nd, matrices)
 @test out[] ≈ tr(foldl(*, matrices))
 
-s = schedule(d, JunctionTreesSchedule())
+s = schedule(d, CliqueTreesSchedule())
 out = eval_schedule(s, matrices)
 @test out[] ≈ tr(foldl(*, matrices))
 
@@ -64,7 +64,7 @@ A, B = randn((3,4)), randn((5,6))
 out = eval_schedule(s, [A, B])
 @test out ≈ (reshape(A, (3,4,1,1)) .* reshape(B, (1,1,5,6)))
 
-s = schedule(d, JunctionTreesSchedule())
+s = schedule(d, CliqueTreesSchedule())
 out = eval_schedule(s, [A, B])
 @test out ≈ (reshape(A, (3,4,1,1)) .* reshape(B, (1,1,5,6)))
 
@@ -80,7 +80,7 @@ A, B = randn((5,5)), randn((5,5))
 out = eval_schedule(s, [A, B])
 @test out[] ≈ dot(vec(A), vec(B))
 
-s = schedule(d, JunctionTreesSchedule())
+s = schedule(d, CliqueTreesSchedule())
 out = eval_schedule(s, [A, B])
 @test out[] ≈ dot(vec(A), vec(B))
 


### PR DESCRIPTION
This pull request adds a scheduling algorithm `CliqueTreesSchedule` calling [CliqueTrees.jl](https://github.com/AlgebraicJulia/CliqueTrees.jl/tree/main), a package I wrote to compute tree decompositions.

The function `dualgraph` could likely be replaced with a data migration, but I cannot quite figure out how.